### PR TITLE
ef-3: get rid of hard-coded port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Demo for PR
+
+PORT fo the service is 3000.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 var express = require('express')
 var app = express()
+const PORT = 3000
 
 app.get('/', function (req, res) {
   res.send('hello world')
 })
 
-app.listen(3000)
+app.listen(PORT)


### PR DESCRIPTION
Summary:
Use a variable instead of the hard-coded number.

Test:
1. `node index.js` to run the service
2. verified that the service is still working by

```shell
╰─ http localhost:3000
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 11
Content-Type: text/html; charset=utf-8
Date: Wed, 09 Mar 2022 20:18:21 GMT
ETag: W/"b-Kq5sNclPz7QV2+lfQIuc6R7oRu0"
Keep-Alive: timeout=5
X-Powered-By: Express

hello world
```


